### PR TITLE
Head fix

### DIFF
--- a/lib/http_router/root.rb
+++ b/lib/http_router/root.rb
@@ -18,7 +18,7 @@ class HttpRouter
         process_response(node, parts, params, request)
       elsif !router.request_methods_specified.empty?
         alternate_methods = (router.request_methods_specified - [request.request_method]).select do |alternate_method|
-          test_request = request.dup
+          test_request = ::Rack::Request.new(request.env.dup)
           test_request.env['REQUEST_METHOD'] = alternate_method
           routes = []
           catch(:match) { find_on_parts(test_request, get_parts(request), [], routes) } || !routes.empty?


### PR DESCRIPTION
Sorry for being short. Sitting on a train.

This fixes the Padrino bug that Requests not hitting a route might return a content-length but not a body.

Accidentally setting the REQUEST_METHOD to HEAD causes Sinatra to delete the body of the response.

http://groups.google.com/group/padrino/browse_thread/thread/09f2ecdc3ac1df9b
