### PR TITLE
Removes bundler deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
Minor fix. Kept getting a bundler deprecation warning because Gemfile was using `:rubygems` instead of something like `https://rubygems.org`.
