### PR TITLE
Use a consistent list of HTTP verbs for validation and helpers

### DIFF
--- a/lib/http_router.rb
+++ b/lib/http_router.rb
@@ -106,40 +106,19 @@ class HttpRouter
     end
   end
 
+  # Creates helper methods for each supported HTTP verb, except GET, which is
+  # a special case that accepts both GET and HEAD requests.
+  Route::VALID_HTTP_VERBS_WITHOUT_GET.each do |request_method|
+    request_method_symbol = request_method.downcase.to_sym
+    define_method(request_method_symbol) do |path, opts = {}, &app|
+      add_with_request_method(path, request_method_symbol, opts, &app)
+    end
+  end
+
   # Adds a path that only responds to the request method +GET+.
   #
   # Returns the route object.
   def get(path, opts = {}, &app); add_with_request_method(path, [:get, :head], opts, &app); end
-
-  # Adds a path that only responds to the request method +POST+.
-  #
-  # Returns the route object.
-  def post(path, opts = {}, &app); add_with_request_method(path, :post, opts, &app); end
-
-  # Adds a path that only responds to the request method +DELETE+.
-  #
-  # Returns the route object.
-  def delete(path, opts = {}, &app); add_with_request_method(path, :delete, opts, &app); end
-
-  # Adds a path that only responds to the request method +PUT+.
-  #
-  # Returns the route object.
-  def put(path, opts = {}, &app); add_with_request_method(path, :put, opts, &app); end
-
-  # Adds a path that only responds to the request method +PATCH+.
-  #
-  # Returns the route object.
-  def patch(path, opts = {}, &app); add_with_request_method(path, :patch, opts, &app); end
-
-  # Adds a path that only responds to the request method +OPTIONS+.
-  #
-  # Returns the route object.
-  def trace(path, opts = {}, &app); add_with_request_method(path, :trace, opts, &app); end
-
-  # Adds a path that only responds to the request method +OPTIONS+.
-  #
-  # Returns the route object.
-  def connect(path, opts = {}, &app); add_with_request_method(path, :connect, opts, &app); end
 
   # Performs recoginition without actually calling the application and returns an array of all
   # matching routes or nil if no match was found.

--- a/lib/http_router/route.rb
+++ b/lib/http_router/route.rb
@@ -2,7 +2,9 @@ require 'set'
 
 class HttpRouter
   class Route
-    VALID_HTTP_VERBS = %w{GET POST PUT DELETE HEAD OPTIONS TRACE}
+    # The list of HTTP request methods supported by HttpRouter.
+    VALID_HTTP_VERBS = %w{GET POST PUT DELETE HEAD OPTIONS TRACE PATCH OPTIONS LINK UNLINK}
+    VALID_HTTP_VERBS_WITHOUT_GET = VALID_HTTP_VERBS - %w{GET}
 
     attr_reader :default_values, :router, :match_partially, :other_hosts, :paths, :request_methods, :name
     attr_accessor :match_partially, :router, :host, :user_agent, :ignore_trailing_slash,

--- a/lib/http_router/route_helper.rb
+++ b/lib/http_router/route_helper.rb
@@ -46,7 +46,9 @@ class HttpRouter
       methods = [methods] unless methods.is_a?(Array)
       methods.each do |method|
         method = method.to_s.upcase
-        raise unless Route::VALID_HTTP_VERBS.include?(method)
+        unless Route::VALID_HTTP_VERBS.include?(method)
+          raise ArgumentError, "Unsupported HTTP request method: #{method}"
+        end
         @request_methods << method
       end
     end
@@ -77,28 +79,17 @@ class HttpRouter
       self
     end
 
-    def head
-      add_request_method "HEAD"
-      self
+    # Creates helper methods for each supported HTTP verb.
+    Route::VALID_HTTP_VERBS_WITHOUT_GET.each do |request_method|
+      define_method(request_method.downcase) do
+        add_request_method(request_method)
+        self
+      end
     end
 
     def get
-      add_request_method "GET"
-      self
-    end
-
-    def post
-      add_request_method "POST"
-      self
-    end
-
-    def put
-      add_request_method "PUT"
-      self
-    end
-
-    def delete
-      add_request_method "DELETE"
+      add_request_method("GET")
+      add_request_method("HEAD")
       self
     end
 


### PR DESCRIPTION
This patch unifies logic related to the supported HTTP verbs. `HttpRouter::Route::VALID_HTTP_VERBS` is now the canonical list of supported verbs. Two verbs were added that were not supported at all before: LINK and UNLINK.

The route helpers in `HttpRouter` and `HttpRouter::RouteHelper` are now dynamically generated from the constant list of valid HTTP verbs, as they were previously inconsistent with each other as to which verbs had helper methods. GET is still defined normally in both objects, since it's a special case that responds to both GET and HEAD.

Additionally, `RouteHelper#add_request_method` will now raise a clearer exception when an unsupported method is used.
