### PR TITLE
Don't assume a router in Route#name=

### DIFF
--- a/lib/http_router/route.rb
+++ b/lib/http_router/route.rb
@@ -26,7 +26,7 @@ class HttpRouter
 
     def name=(name)
       @name = name
-      router.named_routes[name] << self
+      router.named_routes[name] << self if router
     end
   end
 end

--- a/test/test_misc.rb
+++ b/test/test_misc.rb
@@ -118,4 +118,10 @@ class TestMisc < MiniTest::Unit::TestCase
     assert router.inspect.match(/^#<HttpRouter:0x[0-9a-f-]+ number of routes \(3\) ignore_trailing_slash\? \(true\) redirect_trailing_slash\? \(false\)>/)
     assert router.inspect.match(/Path: "\/test" for route unnamed route to :test3/)
   end
+
+  def test_naming_route_with_no_router
+    route = HttpRouter::Route.new
+    route.name = 'named_route'
+    assert_equal 'named_route', route.name
+  end
 end


### PR DESCRIPTION
This patch updates `HttpRouter::Route#name=` so that it doesn't assume the `router` attribute has been set. This is useful when you're creating routes individually and later adding them to a router.