### PR TITLE
Fix many ruby warnings

### DIFF
--- a/http_router.gemspec
+++ b/http_router.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   # dependencies
   s.add_runtime_dependency 'rack',         '>= 1.0.0'
   s.add_runtime_dependency 'url_mount',    '~> 0.2.1'
+  s.add_runtime_dependency 'addressable',   '~> 2.4'
   s.add_development_dependency 'minitest', '~> 2.0.0'
   s.add_development_dependency 'code_stats'
   s.add_development_dependency 'rake',     '~> 0.8.7'

--- a/lib/http_router.rb
+++ b/lib/http_router.rb
@@ -47,6 +47,7 @@ class HttpRouter
     @ignore_trailing_slash   = options && options.key?(:ignore_trailing_slash) ? options[:ignore_trailing_slash] : true
     @redirect_trailing_slash = options && options.key?(:redirect_trailing_slash) ? options[:redirect_trailing_slash] : false
     @route_class             = Route
+    @compiled                = false
     reset!
     instance_eval(&blk) if blk
   end
@@ -118,7 +119,9 @@ class HttpRouter
   # Adds a path that only responds to the request method +GET+.
   #
   # Returns the route object.
-  def get(path, opts = {}, &app); add_with_request_method(path, [:get, :head], opts, &app); end
+  def get(path, opts = {}, &app)
+    add_with_request_method(path, [:get, :head], opts, &app)
+  end
 
   # Performs recoginition without actually calling the application and returns an array of all
   # matching routes or nil if no match was found.

--- a/lib/http_router/generator.rb
+++ b/lib/http_router/generator.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class HttpRouter
   class Generator
     SCHEME_PORTS = {'http' => 80, 'https' => 443}
@@ -36,13 +38,13 @@ class HttpRouter
             instance_eval <<-EOT, __FILE__, __LINE__ + 1
             def generate(args, options)
               generated_path = \"#{code}\"
-              #{validation_regex.inspect}.match(generated_path) ? URI.escape(generated_path) : nil
+              #{validation_regex.inspect}.match(generated_path) ? Addressable::URI.escape(generated_path) : nil
             end
             EOT
           else
             instance_eval <<-EOT, __FILE__, __LINE__ + 1
             def generate(args, options)
-              URI.escape(\"#{code}\")
+              Addressable::URI.escape(\"#{code}\")
             end
             EOT
           end
@@ -55,7 +57,7 @@ class HttpRouter
       @router = @route.router
       @route.generator = self
       @path_generators = @paths.map do |p|
-        generator = PathGenerator.new(route, p.is_a?(String) ? p : route.path_for_generation, p.is_a?(Regexp) ? p : nil)
+        PathGenerator.new(route, p.is_a?(String) ? p : route.path_for_generation, p.is_a?(Regexp) ? p : nil)
       end
     end
 

--- a/lib/http_router/node/abstract_request_node.rb
+++ b/lib/http_router/node/abstract_request_node.rb
@@ -26,6 +26,6 @@ class HttpRouter
       def inspect_label
         "#{self.class.name.split("::").last} #{tests.inspect} (#{@matchers.size} matchers)"
       end
-     end
+    end
   end
 end

--- a/lib/http_router/request.rb
+++ b/lib/http_router/request.rb
@@ -1,3 +1,5 @@
+require 'addressable/uri'
+
 class HttpRouter
   class Request
     attr_accessor :path, :params, :rack_request, :extra_env, :continue, :passed_with, :called
@@ -7,7 +9,7 @@ class HttpRouter
 
     def initialize(path, rack_request)
       @rack_request = rack_request
-      @path = URI.unescape(path).split(/\//)
+      @path = Addressable::URI.unescape(path).split(/\//)
       @path.shift if @path.first == ''
       @path.push('') if path[-1] == ?/
       @extra_env = {}

--- a/lib/http_router/route.rb
+++ b/lib/http_router/route.rb
@@ -3,12 +3,16 @@ require 'set'
 class HttpRouter
   class Route
     # The list of HTTP request methods supported by HttpRouter.
-    VALID_HTTP_VERBS = %w{GET POST PUT DELETE HEAD OPTIONS TRACE PATCH OPTIONS LINK UNLINK}
+    VALID_HTTP_VERBS = %w{GET POST PUT DELETE HEAD OPTIONS TRACE PATCH LINK UNLINK}
     VALID_HTTP_VERBS_WITHOUT_GET = VALID_HTTP_VERBS - %w{GET}
 
     attr_reader :default_values, :other_hosts, :paths, :request_methods, :name
     attr_accessor :match_partially, :router, :host, :user_agent, :ignore_trailing_slash,
                   :path_for_generation, :path_validation_regex, :generator, :scheme, :original_path, :dest
+
+    def initialize
+      @match_with = nil
+    end
 
     def create_clone(new_router)
       r = clone

--- a/lib/http_router/route_helper.rb
+++ b/lib/http_router/route_helper.rb
@@ -108,7 +108,7 @@ class HttpRouter
       @match_partially = true if File.directory?(root)
       to File.directory?(root) ?
         ::Rack::File.new(root) :
-        proc {|env| 
+        proc {|env|
           env['PATH_INFO'] = File.basename(root)
           ::Rack::File.new(File.dirname(root)).call(env)
         }


### PR DESCRIPTION
Addresses most of #44.

Fixing `warning: URI.escape is obsolete` and ` warning: URI.unescape is obsolete` required adding a dependency, on [`Addressable`](https://github.com/sporkmonger/addressable). I hope that's OK! 

All the tests pass (except for `examples/static/config.ru` doesn't run for me, regardless of these changes, see: #46).

Note: this doesn't fix all the Ruby warnings in this project, but rather the ones that `hanami-router` hits in its test suite. I tried to fix others, but they weren't easy fixes (`instance_eval` redefining a method). To run the tests with warnings enabled, you can do: `RUBYOPT=w bundle exec rake test`

Also, I couldn't fix one of the warnings that `hanami-router` hits: `lib/http_router/route_helper.rb:99: warning: assigned but unused variable - params`, because the local variable is referenced in the `eval` call a couple lines down, in one of the tests :/ 