### PR TITLE
Fix env handling for Rack 2

### DIFF
--- a/lib/http_router/node/path.rb
+++ b/lib/http_router/node/path.rb
@@ -29,7 +29,7 @@ class HttpRouter
             request.called = true
             callback.call(Response.new(request, #{path_ivar}))
           else
-            env = request.rack_request.dup.env
+            env = request.rack_request.env
             env['router.request'] = request
             env['router.params'] ||= {}
             #{"env['router.params'].merge!(Hash[#{param_names.inspect}.zip(request.params)])" if dynamic?}


### PR DESCRIPTION
rack#b2d73960e9ea6b8b15321ef190f13a290d1aedf0 introduces the relevant change -
In previous versions, `request.rack_request.dup.env` was still the same object
as `request.rack_request.env` and so updates to it did update the original
rack env, which appears to be behavior that we're depending on elsewhere.

Given that we'll often want to update the env (see e.g.  hanami/controller's
handling of `env['hanami.action']`), I'm struggling to understand why the
`dup` was there in the first place. But in any case, this gets the tests
back passing on Rack '~> 2.0'.
