### PR TITLE
Fix for paths containing '%2F'

### DIFF
--- a/lib/http_router/request.rb
+++ b/lib/http_router/request.rb
@@ -7,7 +7,7 @@ class HttpRouter
 
     def initialize(path, rack_request)
       @rack_request = rack_request
-      @path = URI.unescape(path).split(/\//)
+      @path = path.split('/').map(&URI.method(:unescape))
       @path.shift if @path.first == ''
       @path.push('') if path[-1] == ?/
       @extra_env = {}


### PR DESCRIPTION
The path is split after URI.unescape is called on it, which means that if the path contains '%2F' (the escaped forward slash character), it will be converted to a slash and split on.